### PR TITLE
ci: release with built-in token, PAT only for brew tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -23,7 +25,8 @@ jobs:
           version: '~> v2'
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.GH_PAT }}
 
   docker:
     runs-on: ubuntu-latest
@@ -33,7 +36,7 @@ jobs:
 
       - name: Set output
         id: vars
-        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+        run: echo "tag=${GITHUB_REF#refs/*/}" >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 builds:
   - binary: gherkingen
     main: ./cmd/gherkingen
@@ -58,6 +60,7 @@ brews:
     repository:
       owner: hedhyw
       name: homebrew-gherkingen
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     test: system "#{bin}/gherkingen", "-help"
     install: |-
       bin.install "gherkingen"


### PR DESCRIPTION
Fixes the v4.1.0 release failure (`401 Bad credentials` — stale `GH_PAT`):

- GitHub release now uses the built-in `GITHUB_TOKEN` — no PAT needed
- `GH_PAT` only used for the homebrew-gherkingen formula push
- Also: `::set-output` deprecation fixed, `version: 2` added to goreleaser config

After merge: regenerate `GH_PAT` (write access to homebrew-gherkingen), delete and repush the v4.1.0 tag to rerun the release.